### PR TITLE
LT-2916 do not include currencies in api/assets/ response if product with same ID exists

### DIFF
--- a/src/MarginTrading.AssetService.SqlRepositories/Repositories/AssetsRepository.cs
+++ b/src/MarginTrading.AssetService.SqlRepositories/Repositories/AssetsRepository.cs
@@ -24,12 +24,26 @@ namespace MarginTrading.AssetService.SqlRepositories.Repositories
 
         public async Task<IReadOnlyList<IAsset>> GetAsync()
         {
+            var result = new Dictionary<string, IAsset>();
             using (var context = _contextFactory.CreateDataContext())
             {
                 var products = await context.Products.Where(x => x.IsStarted).Select(x => new Asset(x.ProductId, x.Name, AssetConstants.Accuracy)).ToListAsync();
                 var currencies = await context.Currencies.Select(x => new Asset(x.Id, x.Id, AssetConstants.Accuracy)).ToListAsync();
 
-                return products.Union(currencies).ToList();
+                foreach (var product in products)
+                {
+                    result.Add(product.Id, product);
+                }
+
+                foreach (var currency in currencies)
+                {
+                    if (!result.ContainsKey(currency.Id))
+                    {
+                        result.Add(currency.Id, currency);
+                    }
+                }
+
+                return result.Values.ToList();
             }
         }
 


### PR DESCRIPTION
Should fix:

```
[2020-12-18 05:56:42Z] [FTL] [MT CommissionService:Restart host:Attempts left: 2147483595] -  An exception was thrown while activating λ:MarginTrading.CommissionService.Subscribers.BrokerSettingsSubscriber -> MarginTrading.CommissionService.Services.Handlers.BrokerSettingsChangedHandler.

Autofac.Core.DependencyResolutionException: An exception was thrown while activating λ:MarginTrading.CommissionService.Subscribers.BrokerSettingsSubscriber -> MarginTrading.CommissionService.Services.Handlers.BrokerSettingsChangedHandler.

 ---> System.ArgumentException: An item with the same key has already been added. Key: EUR

   at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)

   at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](List`1 source, Func`2 keySelector, Func`2 elementSelector, IEqualityComparer`1 comparer)

   at MarginTrading.CommissionService.Services.CacheUpdater.InitAssets() in /home/lykkex/buildAgent/work/2b86035e45f1dc69/src/MarginTrading.CommissionService.Services/CacheUpdater.cs:line 74

   at MarginTrading.CommissionService.Services.CacheUpdater.Start() in /home/lykkex/buildAgent/work/2b86035e45f1dc69/src/MarginTrading.CommissionService.Services/CacheUpdater.cs:line 62

   at Autofac.Core.Resolving.InstanceLookup.Execute()

   at Autofac.Core.Resolving.ResolveOperation.GetOrCreateInstance(ISharingLifetimeScope currentOperationScope, ResolveRequest request)

   at Autofac.Core.Activators.Reflection.ConstructorParameterBinding.Instantiate()

   at Autofac.Core.Activators.Reflection.ReflectionActivator.ActivateInstance(IComponentContext context, IEnumerable`1 parameters)

   at Autofac.Core.Resolving.InstanceLookup.CreateInstance(IEnumerable`1 parameters)

   --- End of inner exception stack trace ---

   at Autofac.Core.Resolving.InstanceLookup.CreateInstance(IEnumerable`1 parameters)

   at Autofac.Core.Lifetime.LifetimeScope.CreateSharedInstance(Guid id, Func`1 creator)

   at Autofac.Core.Lifetime.LifetimeScope.CreateSharedInstance(Guid primaryId, Nullable`1 qualifyingId, Func`1 creator)

   at Autofac.Core.Resolving.InstanceLookup.Execute()

   at Autofac.Core.Resolving.ResolveOperation.GetOrCreateInstance(ISharingLifetimeScope currentOperationScope, ResolveRequest request)

   at Autofac.Core.Resolving.ResolveOperation.Execute(ResolveRequest request)

   at Autofac.Builder.StartableManager.StartStartableComponents(IDictionary`2 properties, IComponentContext componentContext)

   at Autofac.ContainerBuilder.Build(ContainerBuildOptions options)

   at Autofac.Extensions.DependencyInjection.AutofacServiceProviderFactory.CreateServiceProvider(ContainerBuilder containerBuilder)

```